### PR TITLE
Fix Player Loop Settings Editor

### DIFF
--- a/Coimbra.Services.PlayerLoopEvents/PlayerLoopInjectedTimings.cs
+++ b/Coimbra.Services.PlayerLoopEvents/PlayerLoopInjectedTimings.cs
@@ -22,7 +22,22 @@ namespace Coimbra.Services.PlayerLoopEvents
         /// <summary>
         /// All events.
         /// </summary>
-        All = ~0,
+        All = FirstInitialization
+        | LastInitialization
+        | FirstEarlyUpdate
+        | LastEarlyUpdate
+        | FirstFixedUpdate
+        | LastFixedUpdate
+        | FirstPreUpdate
+        | LastPreUpdate
+        | FirstUpdate
+        | LastUpdate
+        | PreLateUpdate
+        | FirstPostLateUpdate
+        | PostLateUpdate
+        | LastPostLateUpdate
+        | PreTimeUpdate
+        | PostTimeUpdate,
 
         /// <summary>
         /// Common events for complex systems.


### PR DESCRIPTION
- Unity is breaking enums with a negative flag to set all elements, for now I've manually added a all option with every flag to avoid this bug.